### PR TITLE
Add basic Next.js website

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+Dockerfile
+docker-compose.yml
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.DS_Store
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
-# Lillabjorn
-Website for lilla björn 
+# Lilla Björn
+
+This is a simple website for the **Lilla Björn** project. It is built with [Next.js](https://nextjs.org) so that new pages can easily be added.
+
+## Development
+
+1. Install Node.js (v20 or later).
+2. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+4. Open `http://localhost:3000` in your browser.
+
+## Production
+
+Build the optimized production version and start it:
+
+```bash
+npm run build
+npm start
+```
+
+## Docker
+
+A `Dockerfile` is provided to run the site in a container. Build and run:
+
+```bash
+docker build -t lillabjorn .
+ docker run -p 3000:3000 lillabjorn
+```
+
+The site will be available at `http://localhost:3000`.
+
+## Adding Pages
+
+Create files inside the `pages/` directory. Each file becomes a route. For example, `pages/about.js` is available at `/about`.
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "lillabjorn",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,17 @@
+import Head from 'next/head'
+
+export default function About() {
+  return (
+    <div>
+      <Head>
+        <title>About - Lilla Björn</title>
+      </Head>
+      <main>
+        <h1>About Us</h1>
+        <p>
+          We create handcrafted baby toys from sustainably sourced Swedish wood. Each toy is made with love and care.
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,15 @@
+import Head from 'next/head'
+
+export default function Home() {
+  return (
+    <div>
+      <Head>
+        <title>Lilla Björn</title>
+      </Head>
+      <main>
+        <h1>Welcome to Lilla Björn</h1>
+        <p>Handcrafted Swedish wooden baby toys.</p>
+      </main>
+    </div>
+  )
+}

--- a/public/README.txt
+++ b/public/README.txt
@@ -1,0 +1,1 @@
+Static assets go in this directory.


### PR DESCRIPTION
## Summary
- set up Next.js project skeleton
- add sample pages for home and about
- provide Dockerfile and instructions in README
- add `.gitignore` and `.dockerignore`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e40c94f20832eb6668f4d467b7ead