### PR TITLE
Add menu, gallery, and cute styling

### DIFF
--- a/components/Menu.js
+++ b/components/Menu.js
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function Menu() {
+  return (
+    <nav className="menu">
+      <ul>
+        <li><Link href="/">Home</Link></li>
+        <li><Link href="/about">About</Link></li>
+        <li><Link href="/gallery">Gallery</Link></li>
+      </ul>
+    </nav>
+  )
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import Menu from '../components/Menu'
 
 export default function About() {
   return (
@@ -6,7 +7,8 @@ export default function About() {
       <Head>
         <title>About - Lilla Björn</title>
       </Head>
-        <main>
+      <Menu />
+      <main>
           <h1>About Us</h1>
           <p>
             We create handcrafted baby toys from sustainably sourced Swedish wood. Each toy is made with love and care.

--- a/pages/gallery.js
+++ b/pages/gallery.js
@@ -1,0 +1,21 @@
+import Head from 'next/head'
+import Menu from '../components/Menu'
+
+export default function Gallery() {
+  return (
+    <div>
+      <Head>
+        <title>Gallery - Lilla Björn</title>
+      </Head>
+      <Menu />
+      <main>
+        <h1>Gallery</h1>
+        <div className="cards">
+          <img src="/sample1.svg" alt="Sample toy 1" className="card" />
+          <img src="/sample2.svg" alt="Sample toy 2" className="card" />
+          <img src="/sample3.svg" alt="Sample toy 3" className="card" />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import Menu from '../components/Menu'
 
 export default function Home() {
   return (
@@ -6,6 +7,7 @@ export default function Home() {
       <Head>
         <title>Lilla Björn</title>
       </Head>
+      <Menu />
       <main>
         <h1>Welcome to Lilla Björn</h1>
         <p>Handcrafted Swedish wooden baby toys.</p>
@@ -13,6 +15,29 @@ export default function Home() {
           Our toys are lovingly made to inspire creativity and joy. Each piece
           is carved from local wood and finished with natural oils.
         </p>
+
+        <section>
+          <h2>Customer Reviews</h2>
+          <div className="cards">
+            <div className="card">
+              <p>"These toys are amazing! My baby loves them."</p>
+              <p>- Anna</p>
+            </div>
+            <div className="card">
+              <p>"Beautiful craftsmanship and safe for little hands."</p>
+              <p>- Erik</p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2>Gallery Preview</h2>
+          <div className="cards">
+            <img src="/sample1.svg" alt="Sample toy 1" className="card" />
+            <img src="/sample2.svg" alt="Sample toy 2" className="card" />
+            <img src="/sample3.svg" alt="Sample toy 3" className="card" />
+          </div>
+        </section>
       </main>
     </div>
   )

--- a/public/sample1.svg
+++ b/public/sample1.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="150">
+  <circle cx="75" cy="75" r="70" fill="#ffbbcc" stroke="#d6336c" stroke-width="5" />
+</svg>

--- a/public/sample2.svg
+++ b/public/sample2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="150">
+  <rect x="20" y="20" width="110" height="110" fill="#d4f4dd" stroke="#2c7a7b" stroke-width="5" />
+</svg>

--- a/public/sample3.svg
+++ b/public/sample3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="150">
+  <polygon points="75,15 100,130 50,130" fill="#cce4ff" stroke="#1d4ed8" stroke-width="5" />
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,3 +18,46 @@ main {
 h1 {
   color: #2c3e50;
 }
+
+/* Navigation menu */
+.menu {
+  background-color: #ffe0e9;
+  padding: 1rem 0;
+  border-bottom: 2px solid #f6c5d8;
+  text-align: center;
+}
+
+.menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.menu a {
+  text-decoration: none;
+  color: #d6336c;
+  font-weight: bold;
+}
+
+/* Card styles */
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 200px;
+  text-align: center;
+  display: block;
+}
+


### PR DESCRIPTION
## Summary
- add a navigation menu component
- create a gallery page and sample svg images
- show reviews and gallery preview on the home page
- style the navigation and cards

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e458881a8832eb396019d12a1c2bc