### PR TITLE
Add Impressum page and menu link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@ The site will be available at `http://localhost:3000`.
 ## Adding Pages
 
 Create files inside the `pages/` directory. Each file becomes a route. For example, `pages/about.js` is available at `/about`.
+An `/impressum` page is also included with legal details.
 

--- a/components/Menu.js
+++ b/components/Menu.js
@@ -7,6 +7,7 @@ export default function Menu() {
         <li><Link href="/">Home</Link></li>
         <li><Link href="/about">About</Link></li>
         <li><Link href="/gallery">Gallery</Link></li>
+        <li><Link href="/impressum">Impressum</Link></li>
       </ul>
     </nav>
   )

--- a/components/Menu.test.js
+++ b/components/Menu.test.js
@@ -7,5 +7,6 @@ describe('Menu component', () => {
     expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'About' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Gallery' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Impressum' })).toBeInTheDocument()
   })
 })

--- a/pages/impressum.js
+++ b/pages/impressum.js
@@ -1,0 +1,20 @@
+import Head from 'next/head'
+import Menu from '../components/Menu'
+
+export default function Impressum() {
+  return (
+    <div>
+      <Head>
+        <title>Impressum - Lilla Björn</title>
+      </Head>
+      <Menu />
+      <main>
+        <h1>Impressum</h1>
+        <p>Lilla Björn AB</p>
+        <p>Examplegatan 1, 123 45 Stockholm, Sweden</p>
+        <p>Contact: contact@example.com</p>
+        <p>VAT ID: SE1234567890</p>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/impressum` route with company details
- link Impressum from site navigation
- update menu test
- mention Impressum in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e67d7c858832eac869a80a93ace07