### PR TITLE
Add product search across site

### DIFF
--- a/components/Menu.js
+++ b/components/Menu.js
@@ -7,8 +7,17 @@ export default function Menu() {
         <li><Link href="/">Home</Link></li>
         <li><Link href="/about">About</Link></li>
         <li><Link href="/gallery">Gallery</Link></li>
+        <li><Link href="/products">Products</Link></li>
         <li><Link href="/impressum">Impressum</Link></li>
       </ul>
+      <form action="/products" method="get" className="search">
+        <input
+          type="search"
+          name="q"
+          placeholder="Search products"
+          aria-label="Search products"
+        />
+      </form>
     </nav>
   )
 }

--- a/components/Menu.test.js
+++ b/components/Menu.test.js
@@ -7,6 +7,8 @@ describe('Menu component', () => {
     expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'About' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Gallery' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Products' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Impressum' })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search products')).toBeInTheDocument()
   })
 })

--- a/pages/products.js
+++ b/pages/products.js
@@ -1,0 +1,35 @@
+import Head from 'next/head'
+import Menu from '../components/Menu'
+import { useRouter } from 'next/router'
+
+const products = [
+  { id: 1, name: 'Wooden Rattle' },
+  { id: 2, name: 'Stacking Rings' },
+  { id: 3, name: 'Pull-Along Moose' },
+  { id: 4, name: 'Baby Gym' },
+  { id: 5, name: 'Teething Ring' }
+]
+
+export default function Products() {
+  const router = useRouter()
+  const query = router.query.q ? String(router.query.q).toLowerCase() : ''
+  const filtered = products.filter(p => p.name.toLowerCase().includes(query))
+
+  return (
+    <div>
+      <Head>
+        <title>Products - Lilla Björn</title>
+      </Head>
+      <Menu />
+      <main>
+        <h1>Products</h1>
+        <ul>
+          {filtered.map(p => (
+            <li key={p.id}>{p.name}</li>
+          ))}
+        </ul>
+        {filtered.length === 0 && <p>No products found.</p>}
+      </main>
+    </div>
+  )
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -72,3 +72,14 @@ h1 {
   display: block;
 }
 
+/* Search form */
+.menu .search {
+  margin-top: 0.5rem;
+}
+
+.menu .search input {
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--corner-radius);
+  border: 1px solid #ccc;
+}
+


### PR DESCRIPTION
## Summary
- add `/products` page displaying products
- extend navigation menu with search form and link
- style search form
- adjust tests for new menu items

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e6ba62f6c832eaf59f613f2c114a2