### PR TITLE
Add logo and reusable image grid component

### DIFF
--- a/components/ImageGrid.js
+++ b/components/ImageGrid.js
@@ -1,0 +1,9 @@
+export default function ImageGrid({ images }) {
+  return (
+    <div className="cards">
+      {images.map((img, idx) => (
+        <img key={idx} src={img.src} alt={img.alt} className="card" />
+      ))}
+    </div>
+  )
+}

--- a/components/Menu.js
+++ b/components/Menu.js
@@ -3,6 +3,9 @@ import Link from 'next/link'
 export default function Menu() {
   return (
     <nav className="menu">
+      <Link href="/" className="logo-link">
+        <img src="/logo.svg" alt="Lilla Björn logo" className="logo" />
+      </Link>
       <ul>
         <li><Link href="/">Home</Link></li>
         <li><Link href="/about">About</Link></li>

--- a/pages/gallery.js
+++ b/pages/gallery.js
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import Menu from '../components/Menu'
+import ImageGrid from '../components/ImageGrid'
 
 export default function Gallery() {
   return (
@@ -10,14 +11,16 @@ export default function Gallery() {
       <Menu />
       <main>
         <h1>Gallery</h1>
-        <div className="cards">
-          <img src="/1000020784.jpg" alt="friends 1" className="card" />
-          <img src="/1000020779.jpg" alt="friends 2" className="card" />
-          <img src="/1000020780.jpg" alt="friends 3" className="card" />
-          <img src="/1000020781.jpg" alt="friends 1" className="card" />
-          <img src="/1000020782.jpg" alt="friends 2" className="card" />
-          <img src="/1000020783.jpg" alt="friends 3" className="card" />
-        </div>
+        <ImageGrid
+          images={[
+            { src: '/1000020784.jpg', alt: 'friends 1' },
+            { src: '/1000020779.jpg', alt: 'friends 2' },
+            { src: '/1000020780.jpg', alt: 'friends 3' },
+            { src: '/1000020781.jpg', alt: 'friends 1' },
+            { src: '/1000020782.jpg', alt: 'friends 2' },
+            { src: '/1000020783.jpg', alt: 'friends 3' },
+          ]}
+        />
       </main>
     </div>
   )

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import Menu from '../components/Menu'
+import ImageGrid from '../components/ImageGrid'
 
 export default function Home() {
   return (
@@ -32,14 +33,16 @@ export default function Home() {
 
         <section>
           <h2>Gallery Preview</h2>
-          <div className="cards">
-            <img src="/1000020784.jpg" alt="friends 1" className="card" />
-            <img src="/1000020779.jpg" alt="friends 2" className="card" />
-            <img src="/1000020780.jpg" alt="friends 3" className="card" />
-            <img src="/1000020781.jpg" alt="friends 1" className="card" />
-            <img src="/1000020782.jpg" alt="friends 2" className="card" />
-            <img src="/1000020783.jpg" alt="friends 3" className="card" />
-          </div>
+          <ImageGrid
+            images={[
+              { src: '/1000020784.jpg', alt: 'friends 1' },
+              { src: '/1000020779.jpg', alt: 'friends 2' },
+              { src: '/1000020780.jpg', alt: 'friends 3' },
+              { src: '/1000020781.jpg', alt: 'friends 1' },
+              { src: '/1000020782.jpg', alt: 'friends 2' },
+              { src: '/1000020783.jpg', alt: 'friends 3' },
+            ]}
+          />
         </section>
       </main>
     </div>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48">
+  <circle cx="24" cy="24" r="22" fill="#81af8f" />
+  <text x="24" y="30" text-anchor="middle" font-size="20" fill="white" font-family="Arial, sans-serif">LB</text>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -37,10 +37,12 @@ h1 {
 /* Navigation menu */
 .menu {
   background-color: var(--accent-color);
-  padding: 1rem 0;
+  padding: 0.5rem 1rem;
   border-bottom: 2px solid rgba(0, 0, 0, 0.05);
-  text-align: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .menu ul {
@@ -48,7 +50,6 @@ h1 {
   margin: 0;
   padding: 0;
   display: flex;
-  justify-content: center;
   gap: 1rem;
 }
 
@@ -56,6 +57,16 @@ h1 {
   text-decoration: none;
   color: #fffdfd;
   font-weight: bold;
+}
+
+.logo {
+  height: 40px;
+}
+
+.logo-link {
+  display: flex;
+  align-items: center;
+  margin-right: 1rem;
 }
 
 /* Card styles */
@@ -79,7 +90,7 @@ h1 {
 
 /* Search form */
 .menu .search {
-  margin-top: 0.5rem;
+  margin-left: auto;
 }
 
 .menu .search input {


### PR DESCRIPTION
## Summary
- place a logo link in the navigation menu
- style navigation for logo and search form
- create `ImageGrid` component to reuse image card markup
- use `ImageGrid` on the home and gallery pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e759ae0bc832eadb41ae3308e2c15