### PR TITLE
Implement basket and gallery lightbox

### DIFF
--- a/components/BasketContext.js
+++ b/components/BasketContext.js
@@ -1,0 +1,18 @@
+import { createContext, useContext, useState } from 'react'
+
+const BasketContext = createContext({ items: [], addItem: () => {}, removeItem: () => {} })
+
+export function BasketProvider({ children }) {
+  const [items, setItems] = useState([])
+  const addItem = item => setItems(prev => [...prev, item])
+  const removeItem = id => setItems(prev => prev.filter(p => p.id !== id))
+  return (
+    <BasketContext.Provider value={{ items, addItem, removeItem }}>
+      {children}
+    </BasketContext.Provider>
+  )
+}
+
+export const useBasket = () => useContext(BasketContext)
+
+export default BasketContext

--- a/components/BasketIcon.js
+++ b/components/BasketIcon.js
@@ -1,7 +1,9 @@
 import { useState } from 'react'
+import { useBasket } from './BasketContext'
 
 export default function BasketIcon() {
   const [open, setOpen] = useState(false)
+  const { items, removeItem } = useBasket()
 
   return (
     <>
@@ -17,7 +19,18 @@ export default function BasketIcon() {
       </button>
       {open && (
         <div className="basket">
-          <p>Your basket is empty.</p>
+          {items.length === 0 ? (
+            <p>Your basket is empty.</p>
+          ) : (
+            <ul>
+              {items.map(item => (
+                <li key={item.id}>
+                  {item.name}{' '}
+                  <button onClick={() => removeItem(item.id)}>x</button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
     </>

--- a/components/ImageGrid.js
+++ b/components/ImageGrid.js
@@ -1,19 +1,55 @@
 import Image from 'next/image'
+import { useState } from 'react'
 
 export default function ImageGrid({ images }) {
+  const [active, setActive] = useState(null)
+
+  const showPrev = e => {
+    e.stopPropagation()
+    setActive(i => (i - 1 + images.length) % images.length)
+  }
+  const showNext = e => {
+    e.stopPropagation()
+    setActive(i => (i + 1) % images.length)
+  }
+
   return (
-    <div className="image-grid">
-      {images.map((image, idx) => (
-        <div key={idx} className="grid-item">
-          <Image
-            src={image.src}
-            alt={image.alt}
-            width={image.width}
-            height={image.height}
-            style={{ borderRadius: 'var(--corner-radius)' }}
-          />
+    <>
+      <div className="image-grid">
+        {images.map((image, idx) => (
+          <div
+            key={idx}
+            className="grid-item"
+            onClick={() => setActive(idx)}
+          >
+            <Image
+              src={image.src}
+              alt={image.alt}
+              width={image.width}
+              height={image.height}
+              style={{ borderRadius: 'var(--corner-radius)' }}
+            />
+          </div>
+        ))}
+      </div>
+      {active !== null && (
+        <div className="lightbox" onClick={() => setActive(null)}>
+          <button className="prev" onClick={showPrev} aria-label="Previous">
+            ‹
+          </button>
+          <div className="lightbox-content" onClick={e => e.stopPropagation()}>
+            <Image
+              src={images[active].src}
+              alt={images[active].alt}
+              width={images[active].width * 2}
+              height={images[active].height * 2}
+            />
+          </div>
+          <button className="next" onClick={showNext} aria-label="Next">
+            ›
+          </button>
         </div>
-      ))}
-    </div>
+      )}
+    </>
   )
 }

--- a/components/Menu.js
+++ b/components/Menu.js
@@ -14,7 +14,7 @@ export default function Menu() {
         <input
           type="search"
           name="q"
-          placeholder="Search"
+          placeholder="Search products"
           aria-label="Search"
         />
       </form>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,12 @@
 import '../styles/globals.css'
 import BasketIcon from '../components/BasketIcon'
+import { BasketProvider } from '../components/BasketContext'
 
 export default function App({ Component, pageProps }) {
   return (
-    <>
+    <BasketProvider>
       <Component {...pageProps} />
       <BasketIcon />
-    </>
+    </BasketProvider>
   )
 }

--- a/pages/products.js
+++ b/pages/products.js
@@ -2,17 +2,20 @@ import Head from 'next/head'
 import Menu from '../components/Menu'
 import FadeInSection from '../components/FadeInSection'
 import { useRouter } from 'next/router'
+import Image from 'next/image'
+import { useBasket } from '../components/BasketContext'
 
 const products = [
-  { id: 1, name: 'Wooden Rattle' },
-  { id: 2, name: 'Stacking Rings' },
-  { id: 3, name: 'Pull-Along Moose' },
-  { id: 4, name: 'Baby Gym' },
-  { id: 5, name: 'Teething Ring' }
+  { id: 1, name: 'Wooden Rattle', image: '/sample1.svg' },
+  { id: 2, name: 'Stacking Rings', image: '/sample2.svg' },
+  { id: 3, name: 'Pull-Along Moose', image: '/sample3.svg' },
+  { id: 4, name: 'Baby Gym', image: '/sample1.svg' },
+  { id: 5, name: 'Teething Ring', image: '/sample2.svg' }
 ]
 
 export default function Products() {
   const router = useRouter()
+  const { addItem } = useBasket()
   const query = router.query.q ? String(router.query.q).toLowerCase() : ''
   const filtered = products.filter(p => p.name.toLowerCase().includes(query))
 
@@ -25,11 +28,20 @@ export default function Products() {
       <main>
         <FadeInSection>
           <h1>Products</h1>
-          <ul>
+          <div className="cards">
             {filtered.map(p => (
-              <li key={p.id}>{p.name}</li>
+              <div key={p.id} className="card">
+                <Image
+                  src={p.image}
+                  alt={p.name}
+                  width={150}
+                  height={150}
+                />
+                <h3>{p.name}</h3>
+                <button onClick={() => addItem(p)}>Add to basket</button>
+              </div>
             ))}
-          </ul>
+          </div>
           {filtered.length === 0 && <p>No products found.</p>}
         </FadeInSection>
       </main>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -138,6 +138,50 @@ h2 {
   margin-top: 2rem;
 }
 
+.lightbox {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.lightbox-content {
+  max-width: 90%;
+  max-height: 90%;
+}
+
+.lightbox-content img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--corner-radius);
+}
+
+.lightbox .prev,
+.lightbox .next {
+  position: absolute;
+  background: none;
+  border: none;
+  color: var(--white-color);
+  font-size: 2rem;
+  cursor: pointer;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.lightbox .prev {
+  left: 1rem;
+}
+
+.lightbox .next {
+  right: 1rem;
+}
+
 .grid-item {
   margin-bottom: 1rem;
   border-radius: var(--corner-radius);


### PR DESCRIPTION
## Summary
- add global `BasketContext` to manage basket items
- show basket contents in `BasketIcon`
- show product cards with images and add-to-basket buttons
- allow opening gallery images in a lightbox with previous/next buttons
- tweak menu placeholder text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f88e7e8d0832eb7e8587738d7bf53